### PR TITLE
Bugfix/me training layer metrics graphics

### DIFF
--- a/notebooks/Media/01_Data_Layer.ipynb
+++ b/notebooks/Media/01_Data_Layer.ipynb
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,23 +80,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2021-02-01 19:18:20--  http://files.grouplens.org/datasets/movielens/ml-latest-small.zip\n",
+      "--2021-08-20 07:35:09--  http://files.grouplens.org/datasets/movielens/ml-latest-small.zip\n",
       "Resolving files.grouplens.org (files.grouplens.org)... 128.101.65.152\n",
       "Connecting to files.grouplens.org (files.grouplens.org)|128.101.65.152|:80... connected.\n",
       "HTTP request sent, awaiting response... 200 OK\n",
       "Length: 978202 (955K) [application/zip]\n",
       "Saving to: ‘ml-latest-small.zip’\n",
       "\n",
-      "ml-latest-small.zip 100%[===================>] 955.28K  3.86MB/s    in 0.2s    \n",
+      "100%[======================================>] 978,202     1.38MB/s   in 0.7s   \n",
       "\n",
-      "2021-02-01 19:18:21 (3.86 MB/s) - ‘ml-latest-small.zip’ saved [978202/978202]\n",
+      "2021-08-20 07:35:10 (1.38 MB/s) - ‘ml-latest-small.zip’ saved [978202/978202]\n",
       "\n",
       "Archive:  ml-latest-small.zip\n",
       "   creating: ml-latest-small/\n",
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -343,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -443,7 +443,7 @@
        "4       1       50     5.0  964982931"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -455,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -464,7 +464,7 @@
        "(100836, 4)"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -475,7 +475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -578,7 +578,7 @@
        "max       610.000000  193609.000000       5.000000  1.537799e+09"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -596,7 +596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -623,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -636,7 +636,7 @@
        "dtype: bool"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -665,7 +665,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -700,8 +700,91 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": 12,
    "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>userId</th>\n",
+       "      <th>movieId</th>\n",
+       "      <th>timestamp</th>\n",
+       "      <th>EVENT_TYPE</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>964982703</td>\n",
+       "      <td>watch</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>964981247</td>\n",
+       "      <td>watch</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1</td>\n",
+       "      <td>6</td>\n",
+       "      <td>964982224</td>\n",
+       "      <td>watch</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1</td>\n",
+       "      <td>47</td>\n",
+       "      <td>964983815</td>\n",
+       "      <td>watch</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1</td>\n",
+       "      <td>50</td>\n",
+       "      <td>964982931</td>\n",
+       "      <td>watch</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   userId  movieId  timestamp EVENT_TYPE\n",
+       "0       1        1  964982703      watch\n",
+       "1       1        3  964981247      watch\n",
+       "2       1        6  964982224      watch\n",
+       "3       1       47  964983815      watch\n",
+       "4       1       50  964982931      watch"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "watched_df = original_data.copy()\n",
     "watched_df = watched_df[watched_df['rating'] > 3]\n",
@@ -712,7 +795,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -791,7 +874,7 @@
        "4       1       50  964982931      click"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -806,7 +889,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -818,7 +901,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -852,7 +935,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -946,7 +1029,7 @@
        "max       610.000000  193609.000000  1.537799e+09"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -964,7 +1047,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -977,7 +1060,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -995,7 +1078,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1012,7 +1095,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/Media/01_Data_Layer.ipynb
+++ b/notebooks/Media/01_Data_Layer.ipynb
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,23 +80,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2021-08-20 07:35:09--  http://files.grouplens.org/datasets/movielens/ml-latest-small.zip\n",
+      "--2021-02-01 19:18:20--  http://files.grouplens.org/datasets/movielens/ml-latest-small.zip\n",
       "Resolving files.grouplens.org (files.grouplens.org)... 128.101.65.152\n",
       "Connecting to files.grouplens.org (files.grouplens.org)|128.101.65.152|:80... connected.\n",
       "HTTP request sent, awaiting response... 200 OK\n",
       "Length: 978202 (955K) [application/zip]\n",
       "Saving to: ‘ml-latest-small.zip’\n",
       "\n",
-      "100%[======================================>] 978,202     1.38MB/s   in 0.7s   \n",
+      "ml-latest-small.zip 100%[===================>] 955.28K  3.86MB/s    in 0.2s    \n",
       "\n",
-      "2021-08-20 07:35:10 (1.38 MB/s) - ‘ml-latest-small.zip’ saved [978202/978202]\n",
+      "2021-02-01 19:18:21 (3.86 MB/s) - ‘ml-latest-small.zip’ saved [978202/978202]\n",
       "\n",
       "Archive:  ml-latest-small.zip\n",
       "   creating: ml-latest-small/\n",
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -343,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -443,7 +443,7 @@
        "4       1       50     5.0  964982931"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -455,7 +455,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -464,7 +464,7 @@
        "(100836, 4)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -475,7 +475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -578,7 +578,7 @@
        "max       610.000000  193609.000000       5.000000  1.537799e+09"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -596,7 +596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -623,7 +623,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -636,7 +636,7 @@
        "dtype: bool"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -665,7 +665,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -700,91 +700,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 12,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>userId</th>\n",
-       "      <th>movieId</th>\n",
-       "      <th>timestamp</th>\n",
-       "      <th>EVENT_TYPE</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>964982703</td>\n",
-       "      <td>watch</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1</td>\n",
-       "      <td>3</td>\n",
-       "      <td>964981247</td>\n",
-       "      <td>watch</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1</td>\n",
-       "      <td>6</td>\n",
-       "      <td>964982224</td>\n",
-       "      <td>watch</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1</td>\n",
-       "      <td>47</td>\n",
-       "      <td>964983815</td>\n",
-       "      <td>watch</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>1</td>\n",
-       "      <td>50</td>\n",
-       "      <td>964982931</td>\n",
-       "      <td>watch</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   userId  movieId  timestamp EVENT_TYPE\n",
-       "0       1        1  964982703      watch\n",
-       "1       1        3  964981247      watch\n",
-       "2       1        6  964982224      watch\n",
-       "3       1       47  964983815      watch\n",
-       "4       1       50  964982931      watch"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "watched_df = original_data.copy()\n",
     "watched_df = watched_df[watched_df['rating'] > 3]\n",
@@ -795,7 +712,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -874,7 +791,7 @@
        "4       1       50  964982931      click"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -889,7 +806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -901,7 +818,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -935,7 +852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -1029,7 +946,7 @@
        "max       610.000000  193609.000000  1.537799e+09"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1047,7 +964,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -1060,7 +977,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1078,7 +995,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1095,7 +1012,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/Media/02_Training_Layer.ipynb
+++ b/notebooks/Media/02_Training_Layer.ipynb
@@ -668,8 +668,7 @@
     "\n",
     "When the solutions finish creating, the next step is to obtain the evaluation metrics. Personalize calculates these metrics based on a subset of the training data. The image below illustrates how Personalize splits the data. Given 10 users, with 10 interactions each (a circle represents an interaction), the interactions are ordered from oldest to newest based on the timestamp. Personalize uses all of the interaction data from 90% of the users (blue circles) to train the solution version, and the remaining 10% for evaluation. For each of the users in the remaining 10%, 90% of their interaction data (green circles) is used as input for the call to the trained model. The remaining 10% of their data (orange circle) is compared to the output produced by the model and used to calculate the evaluation metrics.\n",
     "\n",
-    "![personalize metrics](static/imgs/personalize_metrics.png)\n",
-    "TODO: This image is broken\n",
+    "![personalize metrics](../../static/imgs/personalize_metrics.png)\n",
     "\n",
     "We recommend reading [the documentation](https://docs.aws.amazon.com/personalize/latest/dg/working-with-training-metrics.html) to understand the metrics, but we have also copied parts of the documentation below for convenience.\n",
     "\n",
@@ -1072,7 +1071,6 @@
     "\n",
     "As promised, this is how you view the status updates in the console:\n",
     "\n",
-    "TODO: This needs some screencaptures\n",
     "* In another browser tab you should already have the AWS Console open from opening this notebook instance. \n",
     "* Switch to that tab and search at the top for the service `Personalize`, then go to that service page. \n",
     "* Click `View dataset groups`.\n",
@@ -1644,7 +1642,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/Retail/02_Training_Layer.ipynb
+++ b/notebooks/Retail/02_Training_Layer.ipynb
@@ -460,6 +460,8 @@
     "\n",
     "When the solutions finish creating, the next step is to obtain the evaluation metrics. Personalize calculates these metrics based on a subset of the training data. The image below illustrates how Personalize splits the data. Given 10 users, with 10 interactions each (a circle represents an interaction), the interactions are ordered from oldest to newest based on the timestamp. Personalize uses all of the interaction data from 90% of the users (blue circles) to train the solution version, and the remaining 10% for evaluation. For each of the users in the remaining 10%, 90% of their interaction data (green circles) is used as input for the call to the trained model. The remaining 10% of their data (orange circle) is compared to the output produced by the model and used to calculate the evaluation metrics.\n",
     "\n",
+    "![personalize metrics](../../static/imgs/personalize_metrics.png)\n",
+    "\n",
     "We recommend reading [the documentation](https://docs.aws.amazon.com/personalize/latest/dg/working-with-training-metrics.html) to understand the metrics, but we have also copied parts of the documentation below for convenience.\n",
     "\n",
     "You need to understand the following terms regarding evaluation in Personalize:\n",


### PR DESCRIPTION
*Issue #, if available:*
#3 

*Description of changes:*
Added the missing personalize metrics graphs. Removed the TODO for missing screen captures in the M&E notebook, because the Retail notebook doesn't have any as well and the steps are self-explanatory.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
