### PR TITLE
Add watch events to the data in the automation

### DIFF
--- a/automation/ml_ops/script.py
+++ b/automation/ml_ops/script.py
@@ -13,7 +13,11 @@ clicked_df = clicked_df[clicked_df['rating'] > 1]
 clicked_df = clicked_df[['userId', 'movieId', 'timestamp']]
 clicked_df['EVENT_TYPE']='click'
 interactions_df = clicked_df.copy()
-interactions_df = interactions_df.append(clicked_df)
+watched_df = original_data.copy()
+watched_df = watched_df[watched_df['rating'] > 3]
+watched_df = watched_df[['userId', 'movieId', 'timestamp']]
+watched_df['EVENT_TYPE']='watch'
+interactions_df = interactions_df.append(watched_df)
 interactions_df.sort_values("timestamp", axis = 0, ascending = True, inplace = True, na_position ='last') 
 interactions_df.rename(columns = {'userId':'USER_ID', 'movieId':'ITEM_ID', 'timestamp':'TIMESTAMP'}, inplace = True)
 interactions_filename = "interactions.csv"


### PR DESCRIPTION
The automation was missing watch events and duplicating the click events instead.
With this fix the data generated for the automated deployment has both click and watch events.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
