### PR TITLE
Update error handling for S3 bucket creation

### DIFF
--- a/notebooks/CPG/01_Data_Layer.ipynb
+++ b/notebooks/CPG/01_Data_Layer.ipynb
@@ -135,13 +135,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if region == \"us-east-1\":\n",
-    "    s3.create_bucket(Bucket=bucket)\n",
-    "else:\n",
-    "    s3.create_bucket(\n",
-    "        Bucket=bucket,\n",
-    "        CreateBucketConfiguration={'LocationConstraint': region}\n",
-    "        )"
+    "try: \n",
+    "    if region == \"us-east-1\":\n",
+    "        s3.create_bucket(Bucket=bucket)\n",
+    "    else:\n",
+    "        s3.create_bucket(\n",
+    "            Bucket=bucket,\n",
+    "            CreateBucketConfiguration={'LocationConstraint': region}\n",
+    "            )\n",
+    "except s3.exceptions.BucketAlreadyOwnedByYou:\n",
+    "    print(\"Bucket already exists. Using bucket\", bucket_name)"
    ]
   },
   {

--- a/notebooks/Media/01_Data_Layer.ipynb
+++ b/notebooks/Media/01_Data_Layer.ipynb
@@ -765,7 +765,7 @@
     "            Bucket=bucket_name,\n",
     "            CreateBucketConfiguration={'LocationConstraint': region}\n",
     "            )\n",
-    "except:\n",
+    "except s3.exceptions.BucketAlreadyOwnedByYou:\n",
     "    print(\"Bucket already exists. Using bucket\", bucket_name)"
    ]
   },
@@ -1503,7 +1503,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/Retail/01_Data_Layer.ipynb
+++ b/notebooks/Retail/01_Data_Layer.ipynb
@@ -381,7 +381,7 @@
     "            Bucket=bucket_name,\n",
     "            CreateBucketConfiguration={'LocationConstraint': region}\n",
     "            )\n",
-    "except:\n",
+    "except s3.exceptions.BucketAlreadyOwnedByYou:\n",
     "    print(\"Bucket already exists. Using bucket\", bucket_name)"
    ]
   },
@@ -1130,7 +1130,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add better error handling to give a comment if the bucket is already owned
by the user and continue to use it and raise an error otherwise. Fixed in
all 3 use-cases

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
