### PR TITLE
Clean interaction ITEM_IDs to match movie data sets

### DIFF
--- a/notebooks/Media-Pretrained/01_Data_Layer.ipynb
+++ b/notebooks/Media-Pretrained/01_Data_Layer.ipynb
@@ -218,7 +218,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This shows that we have a good range of values for `userId` and `movieId`. Next, it is always a good idea to confirm the data format."
+    "This shows that we have a good range of values for `userId` and `imdbId`. Next, it is always a good idea to confirm the data format."
    ]
   },
   {
@@ -310,7 +310,7 @@
    "source": [
     "watched_df = imdb_data.copy()\n",
     "watched_df = watched_df[watched_df['rating'] > 3]\n",
-    "watched_df = watched_df[['userId', 'movieId', 'timestamp']]\n",
+    "watched_df = watched_df[['userId', 'imdbId', 'timestamp']]\n",
     "watched_df['EVENT_TYPE']='Watch'\n",
     "watched_df.head()"
    ]
@@ -323,7 +323,7 @@
    "source": [
     "clicked_df = imdb_data.copy()\n",
     "clicked_df = clicked_df[clicked_df['rating'] > 1]\n",
-    "clicked_df = clicked_df[['userId', 'movieId', 'timestamp']]\n",
+    "clicked_df = clicked_df[['userId', 'imdbId', 'timestamp']]\n",
     "clicked_df['EVENT_TYPE']='Click'\n",
     "clicked_df.head()"
    ]
@@ -378,8 +378,68 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "interactions_df.rename(columns = {'userId':'USER_ID', 'movieId':'ITEM_ID', \n",
+    "interactions_df.rename(columns = {'userId':'USER_ID', 'imdbId':'ITEM_ID', \n",
     "                              'timestamp':'TIMESTAMP'}, inplace = True) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll be using a subset of the IMDB dataset for this workshop that has been cleaned to remove movies that don't have valid values for the metadata we are using in out ITEMs dataset (we'll work with this more in the net section), so we'll need to make sure we don't have any interactions that have IMDB movie ids that are not in our subset of the IMDB data set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "movies = pd.read_csv(data_dir + '/imdbmeta' + '/imdb_items.csv', sep=',', usecols=[0,1], encoding='latin-1', dtype={'movieId': \"str\", 'imdbId': \"str\", 'tmdbId': \"str\"})\n",
+    "pd.set_option('display.max_rows', 25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, let's compare the number of ITEM_ID unique keys in the IMDB data to the ITEM_ID unique keys in the interactions.  They should be the same."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "movies.nunique(axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interactions_df.nunique(axis=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The number of unique ITEM_IDs are not the same in the IMDB data and the interactions data, so we'll clean out the data points with ITEM_IDs that do not match from interactions dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "interactions_df = interactions_df.merge(movies, on='ITEM_ID')\n",
+    "interactions_df = interactions_df.drop(columns=['TITLE'])\n",
+    "interactions_df.info()"
    ]
   },
   {

--- a/notebooks/Media-Pretrained/01_Data_Layer.ipynb
+++ b/notebooks/Media-Pretrained/01_Data_Layer.ipynb
@@ -218,7 +218,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This shows that we have a good range of values for `userId` and `imdbId`. Next, it is always a good idea to confirm the data format."
+    "This shows that we have a good range of values for `userId` and `movieId`. Next, it is always a good idea to confirm the data format. "
    ]
   },
   {
@@ -629,9 +629,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_python3",
+   "display_name": "Python 3.9.6 64-bit",
    "language": "python",
-   "name": "conda_python3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -643,7 +643,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
1. Remove interactions data points that refer to ITEM_IDs that are not in our movie collection.
2. Minor fix where movieId was being used instead of imdbId

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
