### PR TITLE
Fix error in data preparation

### DIFF
--- a/automation/ml_ops/script-Pretrained.py
+++ b/automation/ml_ops/script-Pretrained.py
@@ -172,7 +172,7 @@ item_data.info()
 
 
 mask = item_data['PLOT'].str.contains('las vegas', case=False, na=False)
-item_data.at[mask, 'PROMOTION'] = 'true'
+item_data.loc[mask, 'PROMOTION'] = 'true'
 item_metadata = item_data
 item_data[mask]
 

--- a/notebooks/Media-Pretrained/01_Data_Layer.ipynb
+++ b/notebooks/Media-Pretrained/01_Data_Layer.ipynb
@@ -391,7 +391,7 @@
    "outputs": [],
    "source": [
     "mask = item_data['PLOT'].str.contains('las vegas', case=False, na=False)\n",
-    "item_data.at[mask, 'PROMOTION'] = 'true'\n",
+    "item_data.loc[mask, 'PROMOTION'] = 'true'\n",
     "item_metadata = item_data\n",
     "item_data[mask]"
    ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The data preparation notebook and script for automated deployment are using Pandas `at` to apply changes to multiple rows of a dataframe, which is not supported.  Changed `at` to `loc`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
