### PR TITLE
Replace pandas .append with .concat

### DIFF
--- a/notebooks/Media-Pretrained/01_Data_Layer.ipynb
+++ b/notebooks/Media-Pretrained/01_Data_Layer.ipynb
@@ -657,7 +657,7 @@
    "outputs": [],
    "source": [
     "interactions_df = clicked_df.copy()\n",
-    "interactions_df = interactions_df.append(watched_df)\n",
+    "interactions_df = pd.concat([interactions_df, watched_df], ignore_index=True)\n",
     "interactions_df.sort_values(\"timestamp\", axis = 0, ascending = True, \n",
     "                 inplace = True, na_position ='last')"
    ]


### PR DESCRIPTION
.append method is deprecated and not available anymore in pandas 2

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
