### PR TITLE
Fix to data notebook because Pandas update deprecated df.append

### DIFF
--- a/notebooks/Media-Pretrained/01_Data_Layer.ipynb
+++ b/notebooks/Media-Pretrained/01_Data_Layer.ipynb
@@ -331,6 +331,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!mkdir poc_data\n",
     "!mkdir poc_data/imdb\n",
     "!cp ../../automation/ml_ops/poc_data/imdb/items.csv poc_data/imdb"
    ]
@@ -657,7 +658,8 @@
    "outputs": [],
    "source": [
     "interactions_df = clicked_df.copy()\n",
-    "interactions_df = interactions_df.append(watched_df)\n",
+    "\n",
+    "interactions_df = pd.concat([interactions_df, watched_df])\n",
     "interactions_df.sort_values(\"timestamp\", axis = 0, ascending = True, \n",
     "                 inplace = True, na_position ='last')"
    ]
@@ -1928,7 +1930,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.10"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Updating the code, because of Pandas update we can no longer use df.append(df) and have to use pd.concat([df, df]) instead

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
